### PR TITLE
Splitted HTML text in order to improve difflib.SequenceMatcher perfor…

### DIFF
--- a/identYwaf.py
+++ b/identYwaf.py
@@ -238,7 +238,7 @@ def check_payload(payload, protection_regex=GENERIC_PROTECTION_REGEX % '|'.join(
     elif options.code:
         result = options.code == intrusive[HTTPCODE]
     else:
-        result = intrusive[HTTPCODE] != original[HTTPCODE] or (intrusive[HTTPCODE] != 200 and intrusive[TITLE] != original[TITLE]) or (re.search(protection_regex, intrusive[HTML]) is not None and re.search(protection_regex, original[HTML]) is None) or (difflib.SequenceMatcher(a=original[HTML] or "", b=intrusive[HTML] or "").ratio() < QUICK_RATIO_THRESHOLD)
+        result = intrusive[HTTPCODE] != original[HTTPCODE] or (intrusive[HTTPCODE] != 200 and intrusive[TITLE] != original[TITLE]) or (re.search(protection_regex, intrusive[HTML]) is not None and re.search(protection_regex, original[HTML]) is None) or (difflib.SequenceMatcher(a=original[HTML].splitlines(1) or "", b=intrusive[HTML].splitlines(1) or "").ratio() < QUICK_RATIO_THRESHOLD)
 
     if not payload.isdigit():
         if result:


### PR DESCRIPTION
During some test the ```difflib.SequenceMatcher``` method seems to be a performance killer. By splitting the HTML text in lines before to invoke the method seems to cause a pretty good improvement in performance.