### PR TITLE
Fix handling of exit for embedded python

### DIFF
--- a/identYwaf.py
+++ b/identYwaf.py
@@ -125,7 +125,7 @@ codes = set()
 proxies = list()
 proxies_index = 0
 
-_exit = exit
+_exit = sys.exit
 
 def exit(message=None):
     if message:


### PR DESCRIPTION
As described in https://docs.python.org/3/library/constants.html#constants-added-by-the-site-module, the constant ``exit`` is imported by the ``site`` module and "useful for the interactive interpreter shell and should not be used in programs." Thus ``sys.exit`` should be used instead.

This bug was encountered when working with "Embeddable Python" (https://docs.python.org/3/using/windows.html#the-embeddable-package), where the ``site`` module is not automatically loaded (since a ``._pth``-file exists by default and prevents this: https://docs.python.org/3/using/windows.html#finding-modules). The https://github.com/sqlmapproject/sqlmap project can not be used in embeddable Python due to this issue.